### PR TITLE
backend: add the date to the .at command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,11 @@ And ``.at`` command::
     (... 2h later ...)
     [19:30] Sopel: Exirel: go to the grocery store
 
+The ``.in`` command accepts time units ranging from days to seconds::
+
+    .in 1d2h In one day and 2 hours
+    .in 2h59m3s In 2 hours, 59 minutes, and 3 seconds
+
 The ``.at`` command is timezone aware, and tries to use the timezone set for
 the user. If not found, it will use the timezone set for the channel. If none
 is set, it will assume UTC+0.
@@ -23,6 +28,16 @@ is set, it will assume UTC+0.
 When using ``.at`` with a past hour, the command will assume tomorrow instead
 of today: setting a reminder for 9 a.m. when it's 10 a.m. will create a
 reminder for 9 a.m. tomorrow.
+
+You can also use a date instead of a time, or you can use both, placed before
+or after the time::
+
+    .at 2023-06-27 Python 3.7 EOL
+    .at 12:00 2023-06-27 Python 3.7 EOL
+    .at 2023-06-27 12:00 Python 3.7 EOL
+
+Passing only a date will set a reminder on that date with *the current time*
+(not adjusted for summer/daylight-savings).
 
 Install
 =======

--- a/sopel_remind/config.py
+++ b/sopel_remind/config.py
@@ -1,4 +1,6 @@
 """Configuration section for plugin."""
+from __future__ import annotations
+
 from sopel.config.types import FilenameAttribute, StaticSection  # type: ignore
 
 

--- a/tests/test_at.py
+++ b/tests/test_at.py
@@ -1,45 +1,140 @@
-from datetime import time
+"""Test functions related to the ``.at`` command"""
+from __future__ import annotations
+
+from datetime import datetime
 
 import pytest
+import pytz
 
 from sopel_remind.backend import parse_at_time
 
-
-def test_parse_at_time_hours():
-    assert parse_at_time('1:00 reminder') == (time(1), 'reminder')
-    assert parse_at_time('01:00 reminder') == (time(1), 'reminder')
+TODAY = pytz.utc.localize(datetime(2023, 6, 17, 10, 13, 10))
 
 
-def test_parse_at_time_hours_minutes():
-    assert parse_at_time('1:20 reminder') == (time(1, 20), 'reminder')
-    assert parse_at_time('01:20 reminder') == (time(1, 20), 'reminder')
+def _convert(raw: str, tzinfo: pytz.BaseTzInfo):
+    """Helper function to convert string into an aware datetime"""
+    return tzinfo.localize(datetime.strptime(raw, '%Y-%m-%d %H:%M:%S'))
 
 
-def test_parse_at_time_hours_minutes_seconds():
-    assert parse_at_time('1:20:30 reminder') == (time(1, 20, 30), 'reminder')
-    assert parse_at_time('01:20:30 reminder') == (time(1, 20, 30), 'reminder')
+def test_parse_at_time_time_only_no_second():
+    """Assert pattern matches hh:mm"""
+    assert parse_at_time('11:20 reminder', TODAY) == (
+        _convert('2023-06-17 11:20:00', pytz.utc), 'reminder'
+    )
 
 
-def test_parse_at_time_invalid():
+def test_parse_at_time_time_only():
+    """Assert pattern matches hh:mm:ss"""
+    assert parse_at_time('11:20:30 reminder', TODAY) == (
+        _convert('2023-06-17 11:20:30', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_time_only_tomorrow():
+    """Assert pattern matches hh:mm[:ss] when it should for tomorrow"""
+    assert parse_at_time('05:20 reminder', TODAY) == (
+        _convert('2023-06-18 05:20:00', pytz.utc), 'reminder'
+    )
+    assert parse_at_time('05:20:30 reminder', TODAY) == (
+        _convert('2023-06-18 05:20:30', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_date():
+    """Assert pattern matches YYYY:MM:DD"""
+    assert parse_at_time('2023-06-18 reminder', TODAY) == (
+        _convert('2023-06-18 10:13:10', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_date_time_no_seconds():
+    """Assert pattern matches YYYY:MM:DD hh:mm"""
+    assert parse_at_time('2023-06-18 17:15 reminder', TODAY) == (
+        _convert('2023-06-18 17:15:00', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_date_time():
+    """Assert pattern matches YYYY:MM:DD hh:mm:ss"""
+    assert parse_at_time('2023-06-18 17:15:39 reminder', TODAY) == (
+        _convert('2023-06-18 17:15:39', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_date_time_today():
+    """Assert pattern matches hh:mm:ss YYYY:MM:DD"""
+    assert parse_at_time('2023-06-17 17:15:39 reminder', TODAY) == (
+        _convert('2023-06-17 17:15:39', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_time_date_no_seconds():
+    """Assert pattern matches hh:mm YYYY:MM:DD"""
+    assert parse_at_time('17:15 2023-06-18 reminder', TODAY) == (
+        _convert('2023-06-18 17:15:00', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_time_date():
+    """Assert pattern matches hh:mm:ss YYYY:MM:DD"""
+    assert parse_at_time('17:15:39 2023-06-18 reminder', TODAY) == (
+        _convert('2023-06-18 17:15:39', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_time_date_today():
+    """Assert pattern matches hh:mm:ss YYYY:MM:DD"""
+    assert parse_at_time('17:15:39 2023-06-17 reminder', TODAY) == (
+        _convert('2023-06-17 17:15:39', pytz.utc), 'reminder'
+    )
+
+
+def test_parse_at_time_invalid_datetime_is_today():
+    """Assert date only or datetime that are today are invalid"""
     with pytest.raises(ValueError):
-        parse_at_time('5 reminder')
+        parse_at_time('2023-06-17 reminder', TODAY)
 
     with pytest.raises(ValueError):
-        parse_at_time('05:0 reminder')
+        parse_at_time('2023-06-17 10:13:10 reminder', TODAY)
 
     with pytest.raises(ValueError):
-        parse_at_time('120:00 reminder')
+        parse_at_time('10:13:10 2023-06-17 reminder', TODAY)
+
+
+def test_parse_at_time_invalid_datetime_is_past():
+    """Assert date only or datetime that are in the past are invalid"""
+    with pytest.raises(ValueError):
+        parse_at_time('2023-06-16 reminder', TODAY)
 
     with pytest.raises(ValueError):
-        parse_at_time('01:130 reminder')
-
-
-def test_parse_at_time_out_of_bound():
-    with pytest.raises(ValueError):
-        parse_at_time('24:00 reminder')
+        parse_at_time('2023-06-17 05:59:10 reminder', TODAY)
 
     with pytest.raises(ValueError):
-        parse_at_time('01:60 reminder')
+        parse_at_time('05:59:10 2023-06-17 reminder', TODAY)
+
+
+def test_parse_at_time_invalid_format():
+    """Assert pattern does not match on invalid time format"""
+    with pytest.raises(ValueError):
+        parse_at_time('5 reminder', TODAY)
 
     with pytest.raises(ValueError):
-        parse_at_time('01:00:60 reminder')
+        parse_at_time('05:0 reminder', TODAY)
+
+    with pytest.raises(ValueError):
+        parse_at_time('120:00 reminder', TODAY)
+
+    with pytest.raises(ValueError):
+        parse_at_time('01:130 reminder', TODAY)
+
+    with pytest.raises(ValueError):
+        parse_at_time('24:00 reminder', TODAY)
+
+    with pytest.raises(ValueError):
+        parse_at_time('2024-13-01 reminder', TODAY)
+
+    with pytest.raises(ValueError):
+        parse_at_time('2024-02-30 reminder', TODAY)
+
+    with pytest.raises(ValueError):
+        parse_at_time('2024-12-32 reminder', TODAY)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import os
 from unittest import mock
@@ -158,32 +160,15 @@ def test_build_reminder(mockbot, triggerfactory):
 
 def test_build_at_reminder(mockbot, triggerfactory):
     trigger = triggerfactory(
-        mockbot, ':Test!test@example.com PRIVMSG #channel :.at 1:30 message')
+        mockbot, ':Test!test@example.com PRIVMSG #channel :.at 01:30 message')
 
     timezone = pytz.timezone('Europe/Paris')
-    today = timezone.localize(datetime.datetime(2021, 9, 28, 10, 0, 0))
-    at_time = datetime.time(11, 0, 0)
+    remind_at = timezone.localize(datetime.datetime(2021, 9, 28, 1, 30, 0))
     message = 'test message'
 
-    reminder = backend.build_at_reminder(trigger, at_time, today, message)
-    expected_at = today = timezone.localize(
-        datetime.datetime(2021, 9, 28, 11, 0, 0))
-
-    assert int(expected_at.timestamp()) == reminder.timestamp
-
-
-def test_build_at_reminder_tomorrow(mockbot, triggerfactory):
-    trigger = triggerfactory(
-        mockbot, ':Test!test@example.com PRIVMSG #channel :.at 1:30 message')
-
-    timezone = pytz.timezone('Europe/Paris')
-    today = timezone.localize(datetime.datetime(2021, 9, 28, 12, 0, 0))
-    at_time = datetime.time(11, 0, 0)
-    message = 'test message'
-
-    reminder = backend.build_at_reminder(trigger, at_time, today, message)
-    expected_at = today = timezone.localize(
-        datetime.datetime(2021, 9, 29, 11, 0, 0))
+    reminder = backend.build_at_reminder(trigger, remind_at, message)
+    expected_at = timezone.localize(
+        datetime.datetime(2021, 9, 28, 1, 30, 0))
 
     assert int(expected_at.timestamp()) == reminder.timestamp
 

--- a/tests/test_in.py
+++ b/tests/test_in.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,6 @@
 """Integration tests for the sopel-remind plugin."""
+from __future__ import annotations
+
 import os
 from datetime import datetime
 from unittest import mock


### PR DESCRIPTION
This is a rework of the .at command's regex to match a reminder time. It adds the possibility to use either a date only, a date with a time, or a time with a date.

This makes the .at command more flexible and more on-part with Sopel 7.1's current .at command.