### PR TITLE
plugin: display full reminder datetime

### DIFF
--- a/sopel_remind/backend.py
+++ b/sopel_remind/backend.py
@@ -281,7 +281,8 @@ def get_reminder_timezone(
     :return: the appropriate timezone for ``reminder``
     """
     return pytz.timezone(tools.time.get_timezone(
-        bot.db,
+        db=bot.db,
+        config=bot.settings,
         nick=reminder.nick,
         channel=reminder.destination,
     ) or 'UTC')
@@ -326,7 +327,8 @@ def get_user_timezone(
         return pytz.utc
 
     return pytz.timezone(tools.time.get_timezone(
-        bot.db,
+        db=bot.db,
+        config=bot.settings,
         nick=nickname,
         channel=channel,
     ) or 'UTC')

--- a/sopel_remind/plugin.py
+++ b/sopel_remind/plugin.py
@@ -11,6 +11,7 @@ from sopel import plugin, tools  # type: ignore
 from sopel.bot import Sopel, SopelWrapper  # type: ignore
 from sopel.config import Config  # type: ignore
 from sopel.config.types import BooleanAttribute  # type: ignore
+from sopel.tools.time import format_time  # type: ignore
 from sopel.trigger import Trigger  # type: ignore
 
 from . import backend, config
@@ -158,10 +159,16 @@ def remind_in(bot: SopelWrapper, trigger: Trigger):
     with LOCK:
         backend.store(bot, reminder)
 
-    when = datetime.fromtimestamp(
-        reminder.timestamp, pytz.utc
-    ).astimezone(backend.get_reminder_timezone(bot, reminder))
-    bot.reply('I will remind you that at %s' % (when.strftime('%H:%M:%S')))
+    when = datetime.fromtimestamp(reminder.timestamp, pytz.utc)
+    display_timezone = backend.get_reminder_timezone(bot, reminder)
+    display_when = format_time(
+        db=bot.db,
+        config=bot.settings,
+        channel=reminder.destination,
+        zone=display_timezone.zone or 'UTC',
+        time=when,
+    )
+    bot.reply('I will remind you that at %s' % display_when)
 
 
 @plugin.command('at')
@@ -203,7 +210,13 @@ def remind_at(bot: SopelWrapper, trigger: Trigger):
     with LOCK:
         backend.store(bot, reminder)
 
-    when = datetime.fromtimestamp(
-        reminder.timestamp, pytz.utc
-    ).astimezone(backend.get_reminder_timezone(bot, reminder))
-    bot.reply('I will remind you that at %s' % (when.strftime('%H:%M:%S')))
+    when = datetime.fromtimestamp(reminder.timestamp, pytz.utc)
+    display_timezone = backend.get_reminder_timezone(bot, reminder)
+    display_when = format_time(
+        db=bot.db,
+        config=bot.settings,
+        channel=reminder.destination,
+        zone=display_timezone.zone or 'UTC',
+        time=when,
+    )
+    bot.reply('I will remind you that at %s' % display_when)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -179,7 +179,11 @@ def test_get_reminder_timezone(mockbot, mockreminder):
         result = backend.get_reminder_timezone(mockbot, mockreminder)
 
     mock_get_timezone.assert_called_once_with(
-        mockbot.db, nick='Test', channel='#channel')
+        db=mockbot.db,
+        config=mockbot.settings,
+        nick='Test',
+        channel='#channel',
+    )
     assert result.zone == 'Europe/Paris'
 
 
@@ -189,7 +193,11 @@ def test_get_reminder_timezone_no_info(mockbot, mockreminder):
         result = backend.get_reminder_timezone(mockbot, mockreminder)
 
     mock_get_timezone.assert_called_once_with(
-        mockbot.db, nick='Test', channel='#channel')
+        db=mockbot.db,
+        config=mockbot.settings,
+        nick='Test',
+        channel='#channel',
+    )
     assert result.zone == 'UTC'
 
 
@@ -203,7 +211,11 @@ def test_get_user_timezone(mockbot, triggerfactory):
             mockbot, trigger.nick, trigger.sender)
 
     mock_get_timezone.assert_called_once_with(
-        mockbot.db, nick='Test', channel='#channel')
+        db=mockbot.db,
+        config=mockbot.settings,
+        nick='Test',
+        channel='#channel',
+    )
     assert result.zone == 'Europe/Paris'
 
 
@@ -217,7 +229,11 @@ def test_get_user_timezone_pm(mockbot, triggerfactory):
             mockbot, trigger.nick, trigger.sender)
 
     mock_get_timezone.assert_called_once_with(
-        mockbot.db, nick='Test', channel=None)
+        db=mockbot.db,
+        config=mockbot.settings,
+        nick='Test',
+        channel=None,
+    )
     assert result.zone == 'Europe/Paris'
 
 
@@ -231,7 +247,11 @@ def test_get_user_timezone_edge_case(mockbot, triggerfactory):
             mockbot, trigger.nick, trigger.sender)
 
     mock_get_timezone.assert_called_once_with(
-        mockbot.db, nick=None, channel='#test')
+        db=mockbot.db,
+        config=mockbot.settings,
+        nick=None,
+        channel='#test',
+    )
     assert result.zone == 'Europe/Paris'
 
 


### PR DESCRIPTION
Tin. Closes #6 

The plugin will now display the reminder's full datetime, using the reminder's timezone, and the channel's time format (or the config one, or a default one).