### PR TITLE
plugin, tests: replace deprecated datetime.utcnow() usage

### DIFF
--- a/sopel_remind/plugin.py
+++ b/sopel_remind/plugin.py
@@ -93,7 +93,7 @@ def reminder_job(bot: Sopel):
         LOGGER.debug('No reminders to send while the bot is not connected.')
         return
 
-    now = int(pytz.utc.localize(datetime.utcnow()).timestamp())
+    now = int(datetime.now(pytz.utc).timestamp())
     kept = []
 
     with LOCK:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -142,7 +142,7 @@ def test_build_reminder(mockbot, triggerfactory):
     trigger = triggerfactory(
         mockbot, ':Test!test@example.com PRIVMSG #channel :.in 5s message')
 
-    now = pytz.utc.localize(datetime.datetime.utcnow())
+    now = datetime.datetime.now(pytz.utc)
     delta = datetime.timedelta(seconds=5)
     message = 'test message'
 
@@ -154,7 +154,7 @@ def test_build_reminder(mockbot, triggerfactory):
     assert reminder.nick == 'Test'
     assert int((now + delta).timestamp()) <= reminder.timestamp
 
-    after_now = pytz.utc.localize(datetime.datetime.utcnow())
+    after_now = datetime.datetime.now(pytz.utc)
     assert int((after_now + delta).timestamp()) >= reminder.timestamp
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -214,7 +214,7 @@ def test_remind_at_invalid_argument(irc, user):
 
 
 def test_shutdown(irc):
-    timestamp = int(datetime.utcnow().timestamp())
+    timestamp = int(datetime.now(pytz.utc).timestamp())
     reminder = Reminder(timestamp, '#channel', 'TestUser', 'Test message.')
     irc.bot.memory[MEMORY_KEY].append(reminder)
     irc.bot.on_close()
@@ -235,7 +235,7 @@ def test_job_no_reminders(irc):
 
 
 def test_job_future_reminders(irc):
-    timestamp = int(pytz.utc.localize(datetime.utcnow()).timestamp()) + 3600
+    timestamp = int(datetime.now(pytz.utc).timestamp()) + 3600
     reminder = Reminder(timestamp, '#channel', 'TestUser', 'Test message.')
     irc.bot.memory[MEMORY_KEY].append(reminder)
 
@@ -245,7 +245,7 @@ def test_job_future_reminders(irc):
 
 
 def test_job_past_reminders(irc):
-    timestamp = int(pytz.utc.localize(datetime.utcnow()).timestamp())
+    timestamp = int(datetime.now(pytz.utc).timestamp())
     irc.bot.memory[MEMORY_KEY].append(
         Reminder(timestamp - 1, '#channel', 'TestUser', 'Test message.'))
     irc.bot.memory[MEMORY_KEY].append(
@@ -276,7 +276,7 @@ def test_job_past_reminders(irc):
 
 
 def test_job_not_connected(irc):
-    timestamp = int(pytz.utc.localize(datetime.utcnow()).timestamp())
+    timestamp = int(datetime.now(pytz.utc).timestamp())
     irc.bot.memory[MEMORY_KEY].append(
         Reminder(timestamp - 1, '#channel', 'TestUser', 'Test message.'))
 
@@ -290,7 +290,7 @@ def test_job_not_connected(irc):
 
 
 def test_job_connected_but_not_registered(irc):
-    timestamp = int(pytz.utc.localize(datetime.utcnow()).timestamp())
+    timestamp = int(datetime.now(pytz.utc).timestamp())
     irc.bot.memory[MEMORY_KEY].append(
         Reminder(timestamp - 1, '#channel', 'TestUser', 'Test message.'))
 


### PR DESCRIPTION
The plugin already uses `pytz`, so use `datetime.now(pytz.utc)` as the replacement call.

Closes #12