### PR TITLE
plugin: add the '.reminders clear' command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,17 +2,16 @@
 sopel-remind
 ============
 
-Sopel plugin ``.in`` command::
+Plugin commands
+===============
+
+The ``.in`` command
+-------------------
+
+Usage::
 
     [17:30] Exirel: .in 2h go to the grocery store
-    [17:30] Sopel: Exirel: I will remind you that at 2023-10-13 -19:30:00CEST
-    (... 2h later ...)
-    [19:30] Sopel: Exirel: go to the grocery store
-
-And ``.at`` command::
-
-    [17:30] Exirel: .at 19:30 go to the grocery store
-    [17:30] Sopel: Exirel: I will remind you that at 2023-10-13 -19:30:00CEST
+    [17:30] Sopel: Exirel: I will remind you that at 2023-10-13 - 19:30:00 CEST
     (... 2h later ...)
     [19:30] Sopel: Exirel: go to the grocery store
 
@@ -20,6 +19,16 @@ The ``.in`` command accepts time units ranging from days to seconds::
 
     .in 1d2h In one day and 2 hours
     .in 2h59m3s In 2 hours, 59 minutes, and 3 seconds
+
+The ``.at`` command
+-------------------
+
+Usage::
+
+    [17:30] Exirel: .at 19:30 go to the grocery store
+    [17:30] Sopel: Exirel: I will remind you that at 2023-10-13 - 19:30:00 CEST
+    (... 2h later ...)
+    [19:30] Sopel: Exirel: go to the grocery store
 
 The ``.at`` command is timezone aware, and tries to use the timezone set for
 the user. If not found, it will use the timezone set for the channel. If none
@@ -39,6 +48,25 @@ or after the time::
 Passing only a date will set a reminder on that date with *the current time*
 (not adjusted for summer/daylight-savings).
 
+Clear your reminders
+--------------------
+
+You can clear your reminders in a channel with the ``.reminders clear``
+command::
+
+    [17:30] Exirel: .in 30min go to the gym
+    [17:30] Sopel: Exirel: I will remind you that at 2023-10-13 - 18:00:00 CEST
+    (... 25min later ...)
+    [17:50] Exirel: .reminders clear
+    [17:50] Sopel (NOTICE): 1 reminder(s) removed for channel #channel.
+
+You can also call it in a **private message**:
+
+* to remove all your **private** reminders
+* or, with a **channel as argument** (e.g., ``.reminders clear #channel``), to
+  privately remove all your reminders for said channel
+
+
 Install
 =======
 
@@ -46,8 +74,9 @@ The recommended way to install this plugin is to use ``pip``::
 
     $ python -m pip install sopel-remind
 
-Note that this plugin requires Python 3.7+ and Sopel 7.1+. It won't work on
+Note that this plugin requires Python 3.8+ and Sopel 8.0+. It won't work on
 Python versions that are not supported by the version of Sopel you are using.
+
 
 Migration from built-in
 =======================

--- a/sopel_remind/backend.py
+++ b/sopel_remind/backend.py
@@ -363,3 +363,30 @@ def store(bot: Union[Sopel, SopelWrapper], reminder: Reminder):
     bot.memory[MEMORY_KEY].append(reminder)
     filename = get_reminder_filename(bot.settings)
     save_reminders(bot.memory[MEMORY_KEY], filename)
+
+
+def clear_reminders(
+    bot: Union[Sopel, SopelWrapper],
+    *,
+    nick: str,
+    destination: str,
+) -> int:
+    """Clear reminders for the given ``nick`` and ``destination``.
+
+    :param nick: owner of the reminders to clear
+    :param destination: destination of the reminders to clear
+    """
+    reminders: list[Reminder] = list(bot.memory[MEMORY_KEY])
+
+    before = len(reminders)
+    bot.memory[MEMORY_KEY] = [
+        reminder
+        for reminder in reminders
+        if reminder.destination != destination or reminder.nick != nick
+    ]
+    after = len(bot.memory[MEMORY_KEY])
+
+    filename = get_reminder_filename(bot.settings)
+    save_reminders(bot.memory[MEMORY_KEY], filename)
+
+    return before - after

--- a/sopel_remind/plugin.py
+++ b/sopel_remind/plugin.py
@@ -224,9 +224,14 @@ def remind_at(bot: SopelWrapper, trigger: Trigger):
 
 @plugin.command('reminders clear')
 def reminders_clear(sopel: SopelWrapper, trigger: Trigger) -> None:
-    """Clear all your reminders for the current channel.
+    """Clear all your channel or private reminders.
 
-    You'll get a notice with the number of reminders cleared for that channel.
+    When used in a channel, this will remove all the reminders you have defined
+    in that channel. When used in a private message, this will remove your
+    private reminders instead.
+
+    In both case you'll get a private NOTICE with the number of reminders
+    removed (if any).
     """
     nick = trigger.nick
     destination = trigger.sender
@@ -238,7 +243,11 @@ def reminders_clear(sopel: SopelWrapper, trigger: Trigger) -> None:
             destination=destination,
         )
 
-    template = '{removed} reminder(s) removed for channel {destination}.'
+    if destination.is_nick():
+        template = '{removed} private reminder(s) removed.'
+    else:
+        template = '{removed} reminder(s) removed for channel {destination}.'
+
     sopel.notice(
         template.format(removed=removed, destination=destination),
         destination=nick,

--- a/sopel_remind/plugin.py
+++ b/sopel_remind/plugin.py
@@ -236,6 +236,13 @@ def reminders_clear(sopel: SopelWrapper, trigger: Trigger) -> None:
     nick = trigger.nick
     destination = trigger.sender
 
+    if option := trigger.group(2):
+        target = sopel.make_identifier(option)
+        if target.is_nick():
+            sopel.notice('"%s" is not a channel.' % target, destination=nick)
+            return
+        destination = target
+
     with LOCK:
         removed = backend.clear_reminders(
             sopel,

--- a/sopel_remind/plugin.py
+++ b/sopel_remind/plugin.py
@@ -220,3 +220,26 @@ def remind_at(bot: SopelWrapper, trigger: Trigger):
         time=when,
     )
     bot.reply('I will remind you that at %s' % display_when)
+
+
+@plugin.command('reminders clear')
+def reminders_clear(sopel: SopelWrapper, trigger: Trigger) -> None:
+    """Clear all your reminders for the current channel.
+
+    You'll get a notice with the number of reminders cleared for that channel.
+    """
+    nick = trigger.nick
+    destination = trigger.sender
+
+    with LOCK:
+        removed = backend.clear_reminders(
+            sopel,
+            nick=nick,
+            destination=destination,
+        )
+
+    template = '{removed} reminder(s) removed for channel {destination}.'
+    sopel.notice(
+        template.format(removed=removed, destination=destination),
+        destination=nick,
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import os
+import typing
 from datetime import datetime
 
 import pytest
@@ -12,6 +13,14 @@ from sopel.tests import rawlist
 from sopel_remind.backend import (MEMORY_KEY, Reminder, get_reminder_filename,
                                   get_reminder_timezone, load_reminders)
 from sopel_remind.plugin import configure, reminder_job
+
+if typing.TYPE_CHECKING:
+    from sopel.bot import Sopel
+    from sopel.config import Config
+    from sopel.tests.factories import (BotFactory, ConfigFactory, IRCFactory,
+                                       UserFactory)
+    from sopel.tests.mocks import MockIRCServer, MockUser
+
 
 TMP_CONFIG = """
 [core]
@@ -24,22 +33,26 @@ enable =
 
 
 @pytest.fixture
-def tmpconfig(configfactory):
+def tmpconfig(configfactory: ConfigFactory) -> Config:
     return configfactory('test.cfg', TMP_CONFIG)
 
 
 @pytest.fixture
-def mockbot(tmpconfig, botfactory):
+def mockbot(tmpconfig: Config, botfactory: BotFactory) -> Sopel:
     return botfactory.preloaded(tmpconfig, preloads=['remind'])
 
 
 @pytest.fixture
-def user(userfactory):
+def user(userfactory: UserFactory) -> MockUser:
     return userfactory('TestUser')
 
 
 @pytest.fixture
-def irc(mockbot, user, ircfactory):
+def irc(
+    mockbot: Sopel,
+    user: MockUser,
+    ircfactory: IRCFactory,
+) -> MockIRCServer:
     server = ircfactory(mockbot)
     server.bot.backend.connected = True
     server.bot._connection_registered.set()  # nasty private-attribute access
@@ -253,11 +266,11 @@ def test_remind_reminders_clear_private_message(irc, userfactory):
 
     irc.say(user, irc.bot.nick, '.in 1d say hi')
     irc.say(user, '#other', '.in 1d say hi')
-    irc.say(not_user, irc.bot.nick, '.in 1d say hi')
+    irc.pm(not_user, '.in 1d say hi')
     assert len(irc.bot.memory[MEMORY_KEY]) == 3, 'Error with the .in command'
     assert len(irc.bot.backend.message_sent) == 3, 'Error with the .in command'
 
-    irc.say(user, irc.bot.nick, '.reminders clear')
+    irc.pm(user, '.reminders clear')
 
     # assert bot's response
     assert len(irc.bot.backend.message_sent[3:]) == 1
@@ -279,6 +292,82 @@ def test_remind_reminders_clear_private_message(irc, userfactory):
     # keep private reminder for another user
     assert irc.bot.memory[MEMORY_KEY][1].destination == 'NotTestUser'
     assert irc.bot.memory[MEMORY_KEY][1].nick == 'NotTestUser'
+
+
+def test_remind_reminders_clear_private_message_with_channel(
+    irc: MockIRCServer,
+    userfactory: UserFactory,
+) -> None:
+    user = userfactory('TestUser')
+    not_user = userfactory('NotTestUser')
+
+    irc.say(user, '#channel', '.in 1d say hi')
+    irc.say(user, '#other', '.in 1d say hi')
+    irc.pm(user, '.in 1d say hi')
+    irc.say(not_user, '#channel', '.in 1d say hi')
+    assert len(irc.bot.memory[MEMORY_KEY]) == 4, 'Error with the .in command'
+    assert len(irc.bot.backend.message_sent) == 4, 'Error with the .in command'
+
+    irc.pm(user, '.reminders clear #channel')
+
+    # assert bot's response
+    assert len(irc.bot.backend.message_sent[4:]) == 1
+    assert irc.bot.backend.message_sent[4:] == rawlist(
+        "NOTICE TestUser :1 reminder(s) removed for channel #channel.",
+    )
+
+    # assert file's content and bot's memory are consistent
+    filename = get_reminder_filename(irc.bot.settings)
+    reminders = load_reminders(filename)
+
+    assert len(reminders) == 3
+    assert reminders == irc.bot.memory[MEMORY_KEY]
+
+    # Other channel reminder is kept
+    assert irc.bot.memory[MEMORY_KEY][0].destination == '#other'
+    assert irc.bot.memory[MEMORY_KEY][0].nick == 'TestUser'
+    # Private reminder is kept
+    assert irc.bot.memory[MEMORY_KEY][1].destination == 'TestUser'
+    assert irc.bot.memory[MEMORY_KEY][1].nick == 'TestUser'
+    # Other user reminder is kept as well
+    assert irc.bot.memory[MEMORY_KEY][2].destination == '#channel'
+    assert irc.bot.memory[MEMORY_KEY][2].nick == 'NotTestUser'
+
+
+def test_remind_reminders_clear_with_nick(
+    irc: MockIRCServer,
+    userfactory: UserFactory,
+) -> None:
+    user = userfactory('TestUser')
+    not_user = userfactory('NotTestUser')
+
+    irc.say(user, '#channel', '.in 1d say hi')
+    irc.say(user, '#other', '.in 1d say hi')
+    irc.pm(user, '.in 1d say hi')
+    irc.say(not_user, '#channel', '.in 1d say hi')
+    expected = list(irc.bot.memory[MEMORY_KEY])
+    assert len(expected) == 4, 'Error with the .in command'
+    assert len(irc.bot.backend.message_sent) == 4, 'Error with the .in command'
+
+    # try with a private message
+    irc.pm(user, '.reminders clear NotTestUser')
+
+    # assert bot's response
+    assert len(irc.bot.backend.message_sent[4:]) == 1
+    assert irc.bot.backend.message_sent[4:] == rawlist(
+        'NOTICE TestUser :"NotTestUser" is not a channel.',
+    )
+    assert irc.bot.memory[MEMORY_KEY] == expected
+
+    # try with a channel message
+    irc.say(user, '#channel', '.reminders clear NotTestUser')
+
+    # assert bot's response
+    assert len(irc.bot.backend.message_sent[5:]) == 1
+    assert irc.bot.backend.message_sent[5:] == rawlist(
+        'NOTICE TestUser :"NotTestUser" is not a channel.',
+    )
+    assert irc.bot.memory[MEMORY_KEY] == expected
 
 
 def test_shutdown(irc):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -213,6 +213,38 @@ def test_remind_at_invalid_argument(irc, user):
     )
 
 
+def test_remind_reminders_clear_channel_self(irc, userfactory):
+    user = userfactory('TestUser')
+    not_user = userfactory('NotTestUser')
+
+    irc.say(user, '#channel', '.in 1d say hi')
+    irc.say(user, '#other', '.in 1d say hi')
+    irc.say(not_user, '#channel', '.in 1d say hi')
+    assert len(irc.bot.memory[MEMORY_KEY]) == 3, 'Error with the .in command'
+    assert len(irc.bot.backend.message_sent) == 3, 'Error with the .in command'
+
+    irc.say(user, '#channel', '.reminders clear')
+
+    # assert bot's response
+    assert len(irc.bot.backend.message_sent[3:]) == 1
+    assert irc.bot.backend.message_sent[3:] == rawlist(
+        "NOTICE TestUser :1 reminder(s) removed for channel #channel.",
+    )
+
+    # assert file's content and bot's memory are consistent
+    filename = get_reminder_filename(irc.bot.settings)
+    reminders = load_reminders(filename)
+
+    assert len(reminders) == 2
+    assert reminders == irc.bot.memory[MEMORY_KEY]
+
+    assert len(irc.bot.memory[MEMORY_KEY]) == 2
+    assert irc.bot.memory[MEMORY_KEY][0].destination == '#other'
+    assert irc.bot.memory[MEMORY_KEY][0].nick == 'TestUser'
+    assert irc.bot.memory[MEMORY_KEY][1].destination == '#channel'
+    assert irc.bot.memory[MEMORY_KEY][1].nick == 'NotTestUser'
+
+
 def test_shutdown(irc):
     timestamp = int(datetime.now(pytz.utc).timestamp())
     reminder = Reminder(timestamp, '#channel', 'TestUser', 'Test message.')


### PR DESCRIPTION
This is the first PR to implement #9 and to allow people to manage their own reminders: this command clear someone's own reminders in the current channel.

Note: draft for now until I implement the PM to Sopel, which I need to investigate further because I'm not exactly sure how it's handled. I think I know, but it's been too long and I don't want to make any mistake here.

Also, for the record: full TDD on this one, and I'm pretty happy about it.