### PR TITLE
fix: auto-migrate built-in reminders on plugin setup

### DIFF
--- a/sopel_remind/backend.py
+++ b/sopel_remind/backend.py
@@ -377,7 +377,10 @@ def setup(bot: Sopel):
     if os.path.isfile(builtin_filename):
         migrated = _migrate_builtin_reminders(builtin_filename, reminders)
         if migrated:
-            LOGGER.info('Migrated %d reminder(s) from built-in plugin.', migrated)
+            LOGGER.info(
+                'Migrated %d reminder(s) from built-in plugin.',
+                migrated,
+            )
             save_reminders(reminders, filename)
         backup_name = builtin_filename + '.bk'
         os.rename(builtin_filename, backup_name)

--- a/sopel_remind/backend.py
+++ b/sopel_remind/backend.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import csv
+import io
 import os
 import re
 from datetime import datetime, timedelta
@@ -342,10 +343,47 @@ def get_reminder_filename(settings: Config) -> str:
     )
 
 
+def _migrate_builtin_reminders(
+    from_file: str,
+    reminders: List[Reminder],
+) -> int:
+    """Migrate reminders from the built-in remind plugin into a list.
+
+    :param from_file: path to the old tab-delimited reminders file
+    :param reminders: list to append migrated reminders to
+    :return: number of reminders migrated
+    """
+    count = 0
+    with io.open(from_file, 'r', encoding='utf-8') as database:
+        for line in database:
+            unixtime, channel, nick, message = line.split('\t', 3)
+            message = message.rstrip('\n')
+            timestamp = int(float(unixtime))
+            reminders.append(Reminder(timestamp, channel, nick, message))
+            count += 1
+    return count
+
+
 def setup(bot: Sopel):
     """Setup action for the plugin."""
     filename = get_reminder_filename(bot.settings)
-    bot.memory[MEMORY_KEY] = load_reminders(filename)
+    reminders = load_reminders(filename)
+
+    # Auto-migrate from built-in remind plugin if old file exists
+    builtin_filename = os.path.join(
+        bot.settings.core.homedir,
+        bot.settings.basename + '.reminders.db',
+    )
+    if os.path.isfile(builtin_filename):
+        migrated = _migrate_builtin_reminders(builtin_filename, reminders)
+        if migrated:
+            LOGGER.info('Migrated %d reminder(s) from built-in plugin.', migrated)
+            save_reminders(reminders, filename)
+        backup_name = builtin_filename + '.bk'
+        os.rename(builtin_filename, backup_name)
+        LOGGER.info('Old reminders file renamed to "%s".', backup_name)
+
+    bot.memory[MEMORY_KEY] = reminders
 
 
 def shutdown(bot: Sopel):

--- a/sopel_remind/plugin.py
+++ b/sopel_remind/plugin.py
@@ -1,7 +1,6 @@
 """Reminder plugin for Sopel."""
 from __future__ import annotations
 
-import io
 import os
 import threading
 from datetime import datetime

--- a/sopel_remind/plugin.py
+++ b/sopel_remind/plugin.py
@@ -68,21 +68,10 @@ def configure(settings: Config) -> None:
 
 def migrate_builtin(from_file: str, to_file: str) -> int:
     """Migrate reminders from the built-in remind plugin."""
-    return_value: int = 0
     reminders = backend.load_reminders(to_file)
-
-    with io.open(from_file, 'r', encoding='utf-8') as database:
-        for i, line in enumerate(database, start=1):
-            unixtime, channel, nick, message = line.split('\t', 3)
-            message = message.rstrip('\n')
-            timestamp = int(float(unixtime))  # ignore microseconds
-            reminders.append(
-                backend.Reminder(timestamp, channel, nick, message)
-            )
-            return_value = i
-
+    count = backend._migrate_builtin_reminders(from_file, reminders)
     backend.save_reminders(reminders, to_file)
-    return return_value
+    return count
 
 
 @plugin.interval(2)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -117,6 +117,74 @@ def test_setup_existing_reminders(mockbot):
     assert mockbot.memory[backend.MEMORY_KEY] == reminders
 
 
+def test_migrate_builtin_reminders(tmp_path):
+    old_file = tmp_path / 'test.reminders.db'
+    old_file.write_text(
+        '1776388089\t#channel\tTestUser\tremind someone about stuff\n'
+        '1857096126\t#channel\tOtherUser\tcheck on things\n',
+        encoding='utf-8',
+    )
+
+    reminders = []
+    count = backend._migrate_builtin_reminders(str(old_file), reminders)
+
+    assert count == 2
+    assert len(reminders) == 2
+    assert reminders[0] == backend.Reminder(
+        1776388089, '#channel', 'TestUser', 'remind someone about stuff')
+    assert reminders[1] == backend.Reminder(
+        1857096126, '#channel', 'OtherUser', 'check on things')
+
+
+def test_setup_auto_migrates_builtin(mockbot):
+    mockbot.settings.define_section('remind', config.RemindSection)
+
+    # Create old-format reminders file in homedir
+    old_file = os.path.join(
+        mockbot.settings.core.homedir, 'test.reminders.db')
+    with open(old_file, 'w', encoding='utf-8') as f:
+        f.write('1776388089\t#channel\tTestUser\tremind someone\n')
+        f.write('1857096126\t#channel\tOtherUser\tcheck things\n')
+
+    backend.setup(mockbot)
+
+    # Reminders should be loaded into memory
+    assert len(mockbot.memory[backend.MEMORY_KEY]) == 2
+    assert mockbot.memory[backend.MEMORY_KEY][0].nick == 'TestUser'
+    assert mockbot.memory[backend.MEMORY_KEY][1].nick == 'OtherUser'
+
+    # Old file should be renamed to .bk
+    assert not os.path.exists(old_file)
+    assert os.path.exists(old_file + '.bk')
+
+    # CSV file should also be written
+    filename = backend.get_reminder_filename(mockbot.settings)
+    saved = backend.load_reminders(filename)
+    assert len(saved) == 2
+
+
+def test_setup_auto_migrates_merges_existing(mockbot):
+    mockbot.settings.define_section('remind', config.RemindSection)
+
+    # Pre-existing CSV reminder
+    filename = backend.get_reminder_filename(mockbot.settings)
+    existing = [backend.Reminder(1700000000, '#channel', 'Existing', 'hello')]
+    backend.save_reminders(existing, filename)
+
+    # Old-format reminders file
+    old_file = os.path.join(
+        mockbot.settings.core.homedir, 'test.reminders.db')
+    with open(old_file, 'w', encoding='utf-8') as f:
+        f.write('1776388089\t#channel\tTestUser\tremind someone\n')
+
+    backend.setup(mockbot)
+
+    # Should have both existing + migrated
+    assert len(mockbot.memory[backend.MEMORY_KEY]) == 2
+    assert mockbot.memory[backend.MEMORY_KEY][0].nick == 'Existing'
+    assert mockbot.memory[backend.MEMORY_KEY][1].nick == 'TestUser'
+
+
 def test_shutdown(mockbot):
     mockbot.settings.define_section('remind', config.RemindSection)
     filename = backend.get_reminder_filename(mockbot.settings)


### PR DESCRIPTION
## Summary
- Moves the built-in remind plugin migration into `backend.setup()` so it runs automatically when the plugin loads, instead of requiring a separate `sopel-plugins configure remind` CLI step
- Extracts migration logic into `backend._migrate_builtin_reminders()` helper, reused by both the automatic setup path and the existing `configure` CLI path
- Adds 3 new tests covering the migration helper, auto-migration on setup, and merging with existing reminders

## Problem
The `sopel-plugins configure remind` migration works for traditional installs where you stop the bot, run the CLI, then restart. However:

1. **Containerized environments (Docker/K8s)**: The bot starts automatically and there's no opportunity to run the interactive CLI migration before the bot process begins.
2. **Race condition**: Even when the CLI migration is run while the bot is running, `reminder_job` (every 2s) overwrites the CSV from its in-memory state, clobbering the migrated reminders.

## Fix
If the old `.reminders.db` file exists when the plugin loads via `setup()`:
1. Reminders are parsed and appended directly into the in-memory list (alongside any existing CSV reminders)
2. The merged list is saved to the CSV file
3. The old file is renamed to `.bk` (same as the CLI path)
4. Migration only runs once (old file is gone after rename)

The existing `configure` CLI path is preserved and now reuses the same `_migrate_builtin_reminders()` helper.

## Test plan
- [x] All 63 existing + new tests pass
- [x] Test with `sopelirc/sopel:8-py3.10` Docker image with an old `.reminders.db` file